### PR TITLE
Add vulnerable version of napi-postinstall

### DIFF
--- a/vulnerable-packages.json
+++ b/vulnerable-packages.json
@@ -3,6 +3,7 @@
   "eslint-plugin-prettier": ["4.2.2", "4.2.3"],
   "is": ["3.3.1", "5.5.0"],
   "got-fetch": ["5.1.11", "5.1.12"],
+  "napi‑postinstall": ["0.3.1"],
   "synckit": ["0.11.9"],
   "@pkgr/core": ["0.2.8"]
 }


### PR DESCRIPTION
Also, according to https://socket.dev/blog/npm-is-package-hijacked-in-expanding-supply-chain-attack#Indicators-of-Compromise-(IOCs), version 0.3.1 of napi-postinstall was compromised too